### PR TITLE
Remove cloudwatch from dev environment

### DIFF
--- a/setup_web_development.yml
+++ b/setup_web_development.yml
@@ -32,11 +32,6 @@
   become: yes
 
   roles:
-    - role: aws_cloudwatch
-      param_name: dev{{ group_id }}
-      param_process_type: web
-      tags: aws_cloudwatch
-
     - role: app_bootstrap
       param_name: dev{{ group_id }}
       param_env_vars: complete

--- a/setup_worker_development.yml
+++ b/setup_worker_development.yml
@@ -31,12 +31,6 @@
   remote_user: ansible
   become: yes
   roles:
-    - role: aws_cloudwatch
-      param_name: dev{{ group_id }}
-      param_group_id: "{{ group_id }}"
-      param_process_type: worker
-      tags: aws_cloudwatch
-
     - role: app_bootstrap
       param_name: dev{{ group_id }}
       param_env_vars: complete


### PR DESCRIPTION
We've never really used cloudwatch logs in the development environment, since we prefer to check `journactl` logs or even stop puma/sidekiq  service and run them manually to check things.

So let's remove this role from the development playbook to save some money.