### PR TITLE
Fix cloudwatch SequenceToken error

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ If you with to submit pull requests, please check the [contribution guide](https
 ## Todo
 
 1. Do not override application files, explain the changes instead;
-2. Temporarily remove webserver from target group during a deploy for true zero downtime;
-3. Fix Cloudwatch stream error when multiple instances use the same stream;
-4. Cleanup how MAX_THREADS is configured in worker instances;
+2. Temporarily remove webserver from target group during a deploy for true zero downtime deploys;
+3. Cleanup how MAX_THREADS is configured in worker instances;
+4. Write teardown playbooks;
 
 ## License
 
@@ -62,5 +62,5 @@ The project is available as open source under the terms of the [MIT License](htt
 
 ## Code of Conduct
 
-Everyone interacting in the Railwat project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/FestaLab/railway/blob/main/CODE_OF_CONDUCT.md).
+Everyone interacting in the Railway project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/FestaLab/railway/blob/main/CODE_OF_CONDUCT.md).
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,5 +3,5 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/focal64"
-  config.vm.synced_folder "./", "/home/vagrant/railway"
+  config.vm.synced_folder "./", "/opt/vagrant/railway"
 end

--- a/roles/aws_cloudwatch/templates/config.j2
+++ b/roles/aws_cloudwatch/templates/config.j2
@@ -11,7 +11,7 @@
         "collect_list": [
           { "file_path": "/var/log/syslog",
             "log_group_name": "{{ app_name }}-ec2-{{ ansible_environment }}",
-            "log_stream_name": "{{ param_process_type }}" }
+            "log_stream_name": "{{ param_hostname }}" }
         ]
       }
     }

--- a/setup_control_production.yml
+++ b/setup_control_production.yml
@@ -32,11 +32,6 @@
   become: yes
 
   roles:
-    - role: aws_cloudwatch
-      param_name: "{{ ansible_environment }}"
-      param_process_type: control
-      tags: aws_cloudwatch
-
     - role: aws_hostname
       param_name: "control{{ play_hosts.index(inventory_hostname) }}"
 

--- a/setup_web_production.yml
+++ b/setup_web_production.yml
@@ -34,6 +34,7 @@
   roles:
     - role: aws_cloudwatch
       param_name: "{{ ansible_environment }}"
+      param_hostname: "web{{ play_hosts.index(inventory_hostname) }}"
       param_process_type: web
       tags: aws_cloudwatch
 

--- a/setup_worker_production.yml
+++ b/setup_worker_production.yml
@@ -33,6 +33,7 @@
   roles:
     - role: aws_cloudwatch
       param_name: "{{ ansible_environment }}"
+      param_hostname: "worker{{ play_hosts.index(inventory_hostname) }}"
       param_process_type: worker
       tags: aws_cloudwatch
 


### PR DESCRIPTION
If multiple Cloudwatch Agent try to log to the same stream they will raise a `SequenceToken` error. So let's change the stream name from being based on the process type (`web`, `worker`) to the hostname (`web0`, `web1`) 