### PR TITLE
Create teardown playbooks for AWS

### DIFF
--- a/docs/CONTRIBUTE.MD
+++ b/docs/CONTRIBUTE.MD
@@ -18,7 +18,7 @@ With this done, you can now go through STEP 5 of the INSTALL.MD file to get your
 ### Teardown
 After you are done and are ready to open your PR, run the teardown playbook:
 ```shell
-ansible-playbook contribute_bootstrap.yml
+ansible-playbook contribute_teardown.yml
 ```
 
 This playbook will:
@@ -30,6 +30,11 @@ This playbook will:
 6 - Clear the development key pair file;
 7 - Copy your current development key pair to `railway-credentials`;
 8 - Clear the development key pair file;
+
+Then also run the teardown playbook to AWS, so it removes every resource that costs money:
+```shell
+ansible-playbook teardown_aws.yml
+```
 
 ### Setup
 If you need to make any changes to your PR, or want to work on something else, instead of doing STEP 5 all over again, you can just run the setup playbook:

--- a/roles/aws_alb_destroy/tasks/main.yml
+++ b/roles/aws_alb_destroy/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+
+- name: Destroying target group named {{ app_name }}-alb-tg-{{ ansible_environment }}-{{ param_name }}
+  community.aws.elb_target_group:
+    name: "{{ app_name }}-alb-tg-{{ ansible_environment }}-{{ item }}"
+    state: absent
+  loop:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+
+- name: Destroying application load balancer named {{ app_name }}-alb-{{ ansible_environment }}-{{ param_name }}
+  community.aws.elb_application_lb:
+    name: "{{ app_name }}-alb-{{ ansible_environment }}-{{ item }}"
+    state: absent
+  loop:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9

--- a/roles/aws_ec2_destroy/tasks/main.yml
+++ b/roles/aws_ec2_destroy/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Destroying instance(s) with id(s) {{ param_instance_id }}
+- name: Destroying EC2 instance(s) with id(s) {{ param_instance_id }}
   amazon.aws.ec2:
     region: "{{ aws_region }}"
     instance_ids: "{{ param_instance_id|trim }}"

--- a/roles/aws_elasticache_destroy/tasks/main.yml
+++ b/roles/aws_elasticache_destroy/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Destroying elasticache instance tagged as {{ app_name }}-elasticache-{{ ansible_environment }}-{{ param_name }}
+  community.aws.elasticache:
+    region: "{{ aws_region }}"
+    name: "{{ app_name }}-elasticache-{{ ansible_environment }}-{{ param_name }}"
+    state: absent
+    wait: False

--- a/roles/aws_rds_destroy/tasks/main.yml
+++ b/roles/aws_rds_destroy/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Destroying RDS instance tagged as {{ app_name }}-db-{{ ansible_environment }}
+  community.aws.rds:
+    region: "{{ aws_region }}"
+    command: delete
+    instance_name: "{{ app_name }}-db-{{ ansible_environment }}"

--- a/teardown_aws.yml
+++ b/teardown_aws.yml
@@ -1,0 +1,36 @@
+---
+
+- hosts: localhost
+  gather_facts: False
+  pre_tasks:
+
+    - community.aws.ec2_instance_info:
+        region: "{{ aws_region }}"
+        filters:
+          "tag:Name": "{{ app_name }}-ec2-{{ ansible_environment }}-*"
+          instance-state-name: ["running"]
+      register: running
+
+    - set_fact:
+        ec2_instances: "{{ running.instances | map(attribute='instance_id') }}"
+
+
+  roles:
+    - role: aws_rds_destroy
+      param_name: development
+      tags: aws_rds_destroy
+
+    - role: aws_elasticache_destroy
+      param_name: "cache"
+      tags: aws_elasticache_destroy
+
+    - role: aws_elasticache_destroy
+      param_name: "job"
+      tags: aws_elasticache_destroy
+
+    - role: aws_ec2_destroy
+      param_instance_id: "{{ ec2_instances }}"
+      tags: aws_elasticache_destroy
+
+    - role: aws_alb_destroy
+      tags: aws_alb_destroy


### PR DESCRIPTION
Adds playbooks for tearing down paid AWS resources created by other playbooks. Will remove

1 - RDS
2 - Elasticache
3 - EC2
4 - Load Balancers